### PR TITLE
Add basic backup all snippets from GitHub username support

### DIFF
--- a/GitHub.py
+++ b/GitHub.py
@@ -39,6 +39,7 @@ def backup_single_github_gist():
 
     print("Backup a single GitHub Gist completed.")
 
+
 def backup_github_gist_from_username():
     """
     Back up all GitHub Gist from a GitHub username which the user will be prompted to input.

--- a/GitHub.py
+++ b/GitHub.py
@@ -47,7 +47,8 @@ def backup_gist_from_username():
     decoded_json_response = response.json()
     total_num_of_github_gists = total_num_of_items_in_all_pages(response,
                                                                 custom_page_size=GITHUB_API_MAX_NUM_OF_PAGE_ITEMS)
-
+    print(f"""There are {total_num_of_github_gists} GitHub Gists found in GitHub username: {github_username}.
+Starting backup...""")
     # TODO: Check for different GitHub Gists but with same file name and backup them as different files.
     #  The current implementation it will override the existing file.
     for github_gist in decoded_json_response:
@@ -55,6 +56,7 @@ def backup_gist_from_username():
         backup_from_raw_files_url(raw_files_url_dict)
 
     print(f"Backup all snippets from the GitHub username: {github_username} completed.")
+
 
 def parse_single_gist_url(raw_gist_url):
     """

--- a/GitHub.py
+++ b/GitHub.py
@@ -4,10 +4,11 @@ Author: LEE WEI HAO JONATHAN (buildevol)
 """
 
 import requests
-from urllib.parse import urlparse
+from urllib.parse import urlparse, parse_qs
 
 GITHUB_API_BASE_URL = "https://api.github.com"
 GITHUB_API_DEFAULT_NUM_OF_PAGE_ITEMS = 30
+GITHUB_API_MAX_NUM_OF_PAGE_ITEMS = 100
 
 CHUNK_SIZE = 1024 * 1024    # 1 MB
 
@@ -26,7 +27,7 @@ def backup_single_github_gist():
     response = requests.get(api_github_url_format)
     response.raise_for_status()
     decoded_json_response = response.json()
-    raw_files_url_dict = get_raw_files_url_from_single_gist_dict(decoded_json_response)
+    raw_files_url_dict = get_raw_files_url_dict_from_single_gist(decoded_json_response)
 
     for file_url in raw_files_url_dict:
         file_response = requests.get(file_url)
@@ -48,9 +49,11 @@ def backup_github_gist_from_username():
     github_username = input("Enter a GitHub username: ")
 
     api_github_url_format = GITHUB_API_BASE_URL + "/users/" + github_username + "/gists"
-    response = requests.get(api_github_url_format)
+    response = requests.get(api_github_url_format, params={"per_page": GITHUB_API_MAX_NUM_OF_PAGE_ITEMS})
     response.raise_for_status()
     decoded_json_response = response.json()
+    total_num_of_github_gists = total_num_of_items_in_all_pages(response,
+                                                                custom_page_size=GITHUB_API_MAX_NUM_OF_PAGE_ITEMS)
 
 
 def parse_single_gist_url(raw_gist_url):
@@ -68,7 +71,7 @@ def parse_single_gist_url(raw_gist_url):
     return parsed_github_gist_url_list
 
 
-def get_raw_files_url_from_single_gist_dict(decoded_json):
+def get_raw_files_url_dict_from_single_gist(decoded_json):
     """
     Parses the input deserialised json to obtain a dict of raw files urls in the GitHub Gist URL.
     :param decoded_json: A deserialised json for a single GitHub Gist from the json returned by GitHub API.
@@ -83,12 +86,23 @@ def get_raw_files_url_from_single_gist_dict(decoded_json):
     return result
 
 
-def total_num_of_items_in_all_pages(link_header_in_response, custom_page_size=GITHUB_API_DEFAULT_NUM_OF_PAGE_ITEMS):
+def total_num_of_items_in_all_pages(response, custom_page_size=GITHUB_API_DEFAULT_NUM_OF_PAGE_ITEMS):
     """
     Calculates the total number of items in all pages based on the input link header response from GitHub API
     and the input custom page size.
-    :param link_header_in_response: The link header response returned by GitHub API.
-    :param custom_page_size: The custom page size whose default value is based on GITHUB_API_DEFAULT_NUM_OF_PAGE_ITEMS
+    :param response: The response returned by GitHub API.
+    :param custom_page_size: The custom page size whose default value is based on GITHUB_API_DEFAULT_NUM_OF_PAGE_ITEMS.
     :return: The total number of items in all pages.
     """
-    pass
+    link_header = response.links
+    if len(link_header) == 0:
+        return len(response.json())
+
+    last_page_url = link_header["last"]["url"]
+    last_page_response = requests.get(last_page_url)
+    query_string = urlparse(last_page_url).query
+    parsed_query_string = parse_qs(query_string)
+    last_page_num = int(parsed_query_string["page"][0])
+
+    return len(last_page_response.json()) + (int(custom_page_size) * (last_page_num - 1))
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Jonathan Lee
+Copyright (c) 2019 LEE WEI HAO JONATHAN
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/SnippetsBackup.py
+++ b/SnippetsBackup.py
@@ -18,8 +18,7 @@ while display_main_menu:
         GitHub.backup_single_github_gist()
         break
     elif user_input == '2':
-        # TODO: To be implemented.
-        GitHub.backup_github_gist_from_username()
+        GitHub.backup_gist_from_username()
         break
     else:
         print("Invalid Input.\n")

--- a/SnippetsBackup.py
+++ b/SnippetsBackup.py
@@ -11,7 +11,7 @@ while display_main_menu:
     print("""Main Menu
 =========
 1. Backup a single GitHub Gist.
-2. Backup all snippets from a GitHub user.""")
+2. Backup all snippets from a GitHub username.""")
 
     user_input = input("Enter a valid option (for example: 1): ")
     if user_input == '1':
@@ -19,7 +19,8 @@ while display_main_menu:
         break
     elif user_input == '2':
         # TODO: To be implemented.
-        pass
+        GitHub.backup_github_gist_from_username()
+        break
     else:
         print("Invalid Input.\n")
         continue


### PR DESCRIPTION
Refactor code
Add basic working implementation for backing up all snippets from GitHub username

Known bug:
If there are duplicate GitHub Gist file names, it will override existing files #4 